### PR TITLE
Build postgres:11+periods Docker image

### DIFF
--- a/90-create-extension-periods.sh
+++ b/90-create-extension-periods.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+  CREATE EXTENSION IF NOT EXISTS periods CASCADE;
+EOSQL

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM debian:10 AS build
+
+RUN mkdir -p /opt/periods
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends devscripts
+
+RUN apt-get install -y --no-install-recommends equivs
+
+ADD . /opt/periods/
+
+WORKDIR /opt/periods
+
+RUN mk-build-deps --install --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' debian/control
+
+RUN make
+
+RUN mkdir -p build-11 && \
+  mv periods.bc periods.so build-11/
+RUN debuild --no-tgz-check -us -uc -b
+
+FROM postgres:11 AS periods
+
+COPY --from=build /opt/postgresql-11-periods_*.deb /tmp/
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  postgresql-11
+
+RUN dpkg -i /tmp/*.deb
+
+ADD 90-create-extension-periods.sh /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Hi,

I'm not sure if you're interested, but thought I'd offer this anyway. This `Dockerfile` builds a `periods` Debian package from the current branch and drops it into a `postgres:11` image along with an init script that creates the `periods` extension on container start.

This is neat if you want to play around with `periods`, simply run this to spin up an instance and get a `psql` shell:

```sh
docker build -t $USER/postgres-periods:latest .
docker run -ti --rm -d -p 5432:5432 $USER/postgres-periods:latest
psql -h localhost -p 5432 -U postgres -w postgres
```

I'd be glad to polish it a bit more and write a few lines for the README if you're interested.